### PR TITLE
update pubspec.yaml as package moved to Flutter Community

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,10 @@
 name: breakpoint
 description: A Flutter plugin to calculate the material design breakpoints.
 version: 1.0.0
-author: Rody Davis <rody.davis.jr@gmail.com>
-homepage: https://github.com/AppleEducate/plugins
+authors:
+ - Flutter Community <community@flutter.zone>
+ - Rody Davis <rody.davis.jr@gmail.com>
+homepage: https://github.com/fluttercommunity/breakpoint
 maintainer: Rody Davis (@AppleEducate)
 
 environment:


### PR DESCRIPTION
The info and links for the package on pub.dev is out of date since the package got moved to Flutter Community. This PR should fix that

cc @AppleEducate 